### PR TITLE
Add template option '-t'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # commit-format
-A tool to check git commit messages format.
+A tool to check your commit messages format.
 
 ## Supported checkers
+
+Primarly disigned for to check for spelling mistakes in commit messages,
+`commit-format` now comes with various checker allowing to:
 
 - Check that each message lines does not exceed a length limit.
 - Check for spelling mistake on commit messages.
@@ -12,8 +15,73 @@ A tool to check git commit messages format.
 $ pip install commit-format
 ```
 
-## Usage
+Help command will show you all availables options:
 
 ```sh
 $ commit-format --help
 ```
+
+## Format options
+
+### -l (--limit INT) Line limit check
+
+You can check that every line in the commit message (including the title/header)
+does not exceed a length limit. By default the value is set to `72`.
+
+A limit of '0' `--limit 0` will disable the line limit checker.
+
+Usage:
+
+```sh
+$ commit-format -l 80
+```
+
+### -ns (--no-spelling) Disable spelling mistake
+
+By default, `commit-format` checks for common spelling mistakes in the commit messages.  
+This option rely on `codespell` and may produce some false-positive results.  
+This new option `-ns` `--no-spelling` let the user disable the spelling checker.
+
+```sh
+$ commit-format -ns
+```
+
+## Behavior option
+
+### -a (--all) Force checking all commits
+
+By default the script will only run on a branch and stop when reaching the base branch.  
+If run on a base branch direclty, the script will throw an error:
+
+```sh
+$ commit-format
+Running on branch main. Abort checking commits.
+```
+
+This measure is there to prevent running the script over past commits.
+
+If running on 'main'/'master' is required, option `-a` will force the script
+to run regadless the branch name.
+
+Usage:
+
+```sh
+$ commit-format -a
+```
+
+### -b (--base) Base branch name
+
+You can set the base branch name according to your project.  
+As described in [option -a section](#a---all-force-checking-all-commits) the base branch name is required
+to let the script restrict it's analysis on the commits of a branch.    
+Default value for the base branch name is `main`.  
+
+Usage:
+
+```sh
+$ commit-format -b master
+```
+
+### -v (--verbosity)
+
+Diplay debug messages from the script.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Primarly disigned for to check for spelling mistakes in commit messages,
 
 - Check that each message lines does not exceed a length limit.
 - Check for spelling mistake on commit messages.
+- `NEW` Check commit header/body/footer against a defined template.
 
 ## Installation
 
@@ -44,6 +45,43 @@ This new option `-ns` `--no-spelling` let the user disable the spelling checker.
 
 ```sh
 $ commit-format -ns
+```
+
+### -t (--template FILE) Template compliance
+
+You can provide a simple INI template to validate the commit header/footer format
+and required symbols.
+
+Usage:
+
+```sh
+$ commit-format -t /path/to/template.ini
+```
+
+Template schema (INI):
+
+- [header]
+  - pattern: Regex that the first line (header) must match.
+- [body]
+  - allow_empty: true/false to allow a commit with only a header (no body).
+  - blank_line_after_header: true/false to enforce a blank line between header and body.
+- [footer]
+  - required: true/false to require a footer section.
+  - pattern: Regex that each footer line must match.
+
+Example `template.ini`:
+
+```ini
+[header]
+pattern = ^(feat: |fix: |doc: |ci: ).+$
+
+[structure]
+allow_empty = false
+blank_line_after_header = true
+
+[footer]
+required = true
+pattern = ^(Signed-off-by: ).+$
 ```
 
 ## Behavior option

--- a/commit_format/commit_format.py
+++ b/commit_format/commit_format.py
@@ -103,7 +103,7 @@ class CommitFormat:
         url_format_error = False
 
         # This variable will handle the full commit message.
-        # It's a line by line agregation with the problematic words highlighted in RED.
+        # It's a line by line aggregation with the problematic words highlighted in RED.
         highlighted_commit_message = ""
     
         # Split the commit message into lines
@@ -115,7 +115,7 @@ class CommitFormat:
             removed_words = []
 
             if (line_number > 1):
-                # A line return must be manually added at the begining of new lines
+                # A line return must be manually added at the beginning of new lines
                 # to rebuild the commit message.
                 highlighted_commit_message += "\n"
 
@@ -160,9 +160,9 @@ class CommitFormat:
 
 def main():
     parser = argparse.ArgumentParser(description="Perform various checks on commit messages.")
-    parser.add_argument('-l', '--lineslimit', type=int, default=0, help="message line max length. Default: '0' (no line limit)")
-    parser.add_argument('-b', '--base', type=str, default="main", help="name of the base branch. Default 'main")
-    parser.add_argument('-a', '--all', action='store_true', help="force check on all commits (including base branch commits)")
+    parser.add_argument('-l', '--limit', type=int, default=72, help="commit lines maximum length. Default: '72' ('0' => no line limit)")
+    parser.add_argument('-b', '--base', type=str, default="main", help="name of the base branch. Default 'main'")
+    parser.add_argument('-a', '--all', action='store_true', help="check all commits (including base branch commits)")
     parser.add_argument('-v', '--verbosity', action='store_true', help="increase output verbosity")
     args = parser.parse_args()
 
@@ -189,7 +189,7 @@ def main():
         error_on_commit = 0
         commit_message = commit_format.get_commit_message(commit)
         error_on_commit += commit_format.spell_check(commit, commit_message)
-        error_on_commit += commit_format.lines_length(commit, commit_message, args.lineslimit)
+        error_on_commit += commit_format.lines_length(commit, commit_message, args.limit)
 
         if not error_on_commit:
             commit_format.info(f"{GREEN}Commit {commit} OK{RESET}")

--- a/commit_format/commit_format.py
+++ b/commit_format/commit_format.py
@@ -160,6 +160,7 @@ class CommitFormat:
 
 def main():
     parser = argparse.ArgumentParser(description="Perform various checks on commit messages.")
+    parser.add_argument('-ns', '--no-spelling',  action='store_true', help="disable checking misspelled words")
     parser.add_argument('-l', '--limit', type=int, default=72, help="commit lines maximum length. Default: '72' ('0' => no line limit)")
     parser.add_argument('-b', '--base', type=str, default="main", help="name of the base branch. Default 'main'")
     parser.add_argument('-a', '--all', action='store_true', help="check all commits (including base branch commits)")
@@ -188,7 +189,8 @@ def main():
     for commit in commit_list:
         error_on_commit = 0
         commit_message = commit_format.get_commit_message(commit)
-        error_on_commit += commit_format.spell_check(commit, commit_message)
+        if args.no_spelling == False:
+            error_on_commit += commit_format.spell_check(commit, commit_message)
         error_on_commit += commit_format.lines_length(commit, commit_message, args.limit)
 
         if not error_on_commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "commit_format"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
   { name="Alex Fabre", email="m.alexfabre@gmail.com" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-codespell==2.4.1
+codespell>=2.4.1

--- a/template.ini
+++ b/template.ini
@@ -1,6 +1,6 @@
 [header]
 # header line regex:
-pattern = ^(option: |requirements: |doc: ).+$
+pattern = ^(option: |requirements: |doc: |release: ).+$
 
 [body]
 # Allow empty body commit message. (i.e. single line commit message).

--- a/template.ini
+++ b/template.ini
@@ -1,0 +1,15 @@
+[header]
+# header line regex:
+pattern = ^(option: |requirements: |doc: ).+$
+
+[body]
+# Allow empty body commit message. (i.e. single line commit message).
+allow_empty = false
+# Require that header line and body line are separated by an empty line.
+blank_line_after_header = true
+
+[footer]
+# Require a footer line
+required = true
+# Footer line regex
+pattern = ^(Signed-off-by: |Co-authored-by: |Refs: |Fixes: ).+$


### PR DESCRIPTION
This PR brings the template option to define a common template for the whole commits

This PR also brings breaking changes on the `-l` option, requiring to bump to `v0.2.0`
 