### PR TITLE
ci: install requirements through dedicated file

### DIFF
--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install codespell
+        pip install -r requirements.txt
     - name: commit-format 
       run: |
         git fetch --no-tags --depth=1 origin main


### PR DESCRIPTION
Instead of installing codespell manually, install through 'requirements.txt'