### PR TITLE
ci: prevent commit-format workflow on main

### DIFF
--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -1,6 +1,9 @@
 name: commit-format 🔍
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
commit-format is not meant to be run on the base branch (main)