### PR TITLE
Add UX improvements, unit tests, and CI pipelines

### DIFF
--- a/.commit-format
+++ b/.commit-format
@@ -1,6 +1,6 @@
 [header]
 # header line regex:
-pattern = ^(option: |requirements: |ci: |doc: |release: |script: ).+$
+pattern = ^(option: |requirements: |ci: |doc: |release: |script: |format: ).+$
 
 [body]
 # Allow empty body commit message. (i.e. single line commit message).

--- a/.github/workflows/commit-format.yml
+++ b/.github/workflows/commit-format.yml
@@ -1,4 +1,4 @@
-name: commit-format 🔍
+name: Lint commits
 
 on:
   push:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,4 +1,4 @@
-name: markdownlint
+name: Lint markdown
 
 on: [push]
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,4 @@
-name: Pylint 🐍
+name: Lint with Pylint
 
 on: [push]
 
@@ -17,7 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install pylint
-    - name: Pylint 🐍
+    - name: Lint with Pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: Lint with Pylint
+name: Run Unit Test via Pytest
 
 on: [push]
 
@@ -11,14 +11,20 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install pylint pytest
-    - name: Lint with Pylint
-      run: |
-        pylint $(git ls-files '*.py')
+        pip install pytest pytest-md pytest-emoji
+    - name: Run pytest
+      uses: pavelzw/pytest-action@v2.2.0
+      with:
+        verbose: true
+        emoji: true
+        job-summary: true
+        custom-arguments: '-q'
+        click-to-expand: true
+        report-title: 'Test Report'

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,26 @@
+name: Lint with Ruff
+
+on: [push]
+
+jobs:
+  quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Ruff lint
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "latest"
+          args: "check --output-format=github"
+
+      - name: Run Ruff Format
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "latest"
+          args: "format --check --respect-gitignore"
+      

--- a/commit_format/__init__.py
+++ b/commit_format/__init__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__author__ = 'Alex Fabre'
+__author__ = "Alex Fabre"

--- a/commit_format/commit_format.py
+++ b/commit_format/commit_format.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import re
 import configparser
+import os
 from importlib.metadata import version, PackageNotFoundError
 from urllib.parse import urlparse
 
@@ -372,6 +373,35 @@ class CommitFormat:
         return errors
 
 
+def find_config_file() -> str | None:
+    """Auto-discover config file in current directory or git root."""
+    candidates = [".commit-format", ".commit-format.toml"]
+
+    # Check current directory first
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+
+    # Check git root directory
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            git_root = result.stdout.strip()
+            for candidate in candidates:
+                path = os.path.join(git_root, candidate)
+                if os.path.isfile(path):
+                    return path
+    except FileNotFoundError:
+        pass
+
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Perform various checks on commit messages."
@@ -420,8 +450,14 @@ def main():
 
     commit_format = CommitFormat(verbosity=args.verbosity)
 
-    if args.template:
-        commit_format.load_template(args.template)
+    template_path = args.template
+    if not template_path:
+        template_path = find_config_file()
+        if template_path:
+            commit_format.debug(f"Auto-discovered config: {template_path}")
+
+    if template_path:
+        commit_format.load_template(template_path)
 
     error_found = 0
     current_branch = commit_format.get_current_branch()

--- a/commit_format/commit_format.py
+++ b/commit_format/commit_format.py
@@ -10,7 +10,15 @@ import subprocess
 import sys
 import re
 import configparser
+from importlib.metadata import version, PackageNotFoundError
 from urllib.parse import urlparse
+
+
+def get_version() -> str:
+    try:
+        return version("commit_format")
+    except PackageNotFoundError:
+        return "dev"
 
 # ANSI escape codes for colors
 RED = '\033[91m'
@@ -321,6 +329,9 @@ class CommitFormat:
 
 def main():
     parser = argparse.ArgumentParser(description="Perform various checks on commit messages.")
+    parser.add_argument('-V', '--version',
+                        action='version',
+                        version=f'%(prog)s {get_version()}')
     parser.add_argument('-ns', '--no-spelling',
                         action='store_true',
                         help="disable checking misspelled words")

--- a/commit_format/commit_format.py
+++ b/commit_format/commit_format.py
@@ -20,12 +20,14 @@ def get_version() -> str:
     except PackageNotFoundError:
         return "dev"
 
+
 # ANSI escape codes for colors
-RED = '\033[91m'
-YELLOW = '\033[93m'
-GREEN = '\033[92m'
-BLUE = '\033[94m'
-RESET = '\033[0m'
+RED = "\033[91m"
+YELLOW = "\033[93m"
+GREEN = "\033[92m"
+BLUE = "\033[94m"
+RESET = "\033[0m"
+
 
 def is_url(url: str) -> bool:
     try:
@@ -34,18 +36,20 @@ def is_url(url: str) -> bool:
     except ValueError:
         return False
 
+
 def contains_url(string: str) -> bool:
-    if '/' not in string:
+    if "/" not in string:
         return False
 
     # Split on '(', ')', '[', ']', and space ' '
-    word_list = re.split(r'[()\[\]\s]', string)
+    word_list = re.split(r"[()\[\]\s]", string)
 
     for w in word_list:
         if is_url(w):
             return True
 
     return False
+
 
 class CommitFormat:
     def __init__(self, verbosity=False):
@@ -60,17 +64,20 @@ class CommitFormat:
         """Prints the given text in yellow."""
         print(f"{YELLOW}{text}{RESET}")
 
-    def highlight_words_in_txt(self, text: str, words="", highlight_color=f"{RED}") -> str:
+    def highlight_words_in_txt(
+        self, text: str, words="", highlight_color=f"{RED}"
+    ) -> str:
         """Prints the given text and highlights the words in the list."""
         for word in words:
             word = self.remove_ansi_color_codes(word)
-            text = text[::-1].replace(f"{word}"[::-1],
-                                      f"{highlight_color}{word}{RESET}"[::-1], 1)[::-1]
+            text = text[::-1].replace(
+                f"{word}"[::-1], f"{highlight_color}{word}{RESET}"[::-1], 1
+            )[::-1]
         return text
 
     def remove_ansi_color_codes(self, text: str) -> str:
-        ansi_escape_pattern = re.compile(r'\x1B[@-_][0-?]*[ -/]*[@-~]')
-        return ansi_escape_pattern.sub('', text)
+        ansi_escape_pattern = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
+        return ansi_escape_pattern.sub("", text)
 
     def info(self, text: str):
         """Prints the given text in blue."""
@@ -83,42 +90,66 @@ class CommitFormat:
 
     def get_current_branch(self) -> str:
         self.debug("get_current_branch: git rev-parse --abbrev-ref HEAD")
-        result = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-                                capture_output=True, text=True, check=False)
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
         return result.stdout.strip()
 
     def list_unique_commits(self, current_branch, base_branch) -> list:
         if current_branch != base_branch:
-            self.debug("list_unique_commits: git log --pretty=format:%h "
-                       f"{base_branch}..{current_branch}")
-            result = subprocess.run(['git', 'log', '--pretty=format:%h',
-                                     f'{base_branch}..{current_branch}'],
-                                     capture_output=True,
-                                     text=True, check=False)
+            self.debug(
+                "list_unique_commits: git log --pretty=format:%h "
+                f"{base_branch}..{current_branch}"
+            )
+            result = subprocess.run(
+                [
+                    "git",
+                    "log",
+                    "--pretty=format:%h",
+                    f"{base_branch}..{current_branch}",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
             return result.stdout.split()
 
         self.error(f"Running on branch {base_branch}. Abort checking commits.")
         sys.exit(0)
 
     def list_all_commits(self) -> list:
-        result = subprocess.run(['git', 'log', '--pretty=format:%h'],
-                                capture_output=True, text=True, check=False)
+        result = subprocess.run(
+            ["git", "log", "--pretty=format:%h"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
         return result.stdout.split()
 
     def get_commit_message(self, commit_sha: str) -> str:
-        result = subprocess.run(['git', 'show', '-s', '--format=%B', commit_sha],
-                                capture_output=True,
-                                text=True, check=False)
+        result = subprocess.run(
+            ["git", "show", "-s", "--format=%B", commit_sha],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
         return result.stdout.strip()
 
     def run_codespell(self, message: str) -> tuple:
-        result = subprocess.run(['codespell', '-c', '-', '-'], input=message,
-                                capture_output=True,
-                                text=True, check=False)
-        lines = result.stdout.strip().split('\n')
+        result = subprocess.run(
+            ["codespell", "-c", "-", "-"],
+            input=message,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        lines = result.stdout.strip().split("\n")
         selected_lines = [line for index, line in enumerate(lines) if index % 2 != 0]
         faulty_words = [line.split()[0] for line in selected_lines if line]
-        return '\n'.join(selected_lines), faulty_words
+        return "\n".join(selected_lines), faulty_words
 
     def spell_check(self, commit: str, commit_message: str) -> bool:
         spell_error = 0
@@ -128,7 +159,9 @@ class CommitFormat:
         if codespell_proposition:
             spell_error += 1
             self.warning(f"Commit {commit} has spelling mistakes")
-            self.info(self.highlight_words_in_txt(f"---\n{commit_message}", faulty_words))
+            self.info(
+                self.highlight_words_in_txt(f"---\n{commit_message}", faulty_words)
+            )
             self.info(f"---\nCodespell fix proposition:\n{codespell_proposition}\n---")
 
         # Run another spelling tool:
@@ -150,7 +183,7 @@ class CommitFormat:
         highlighted_commit_message = ""
 
         # Split the commit message into lines
-        lines = commit_message.split('\n')
+        lines = commit_message.split("\n")
 
         # Check if any line exceeds the length limit
         for line in lines:
@@ -179,9 +212,9 @@ class CommitFormat:
                 # Split the line into words
                 while len(line_copy) > length_limit:
                     # Find the last space in the line
-                    last_space_index = line_copy.rfind(' ')
+                    last_space_index = line_copy.rfind(" ")
 
-                    removed_word = line_copy[(last_space_index+1):]
+                    removed_word = line_copy[(last_space_index + 1) :]
                     removed_words.append(removed_word)
 
                     # Remove the last word by slicing up to the last space (if there was any space)
@@ -190,7 +223,9 @@ class CommitFormat:
                     else:
                         line_copy = line_copy[:last_space_index]
 
-            highlighted_commit_message += f"{self.highlight_words_in_txt(line, removed_words)}"
+            highlighted_commit_message += (
+                f"{self.highlight_words_in_txt(line, removed_words)}"
+            )
 
         if length_exceeded:
             if url_format_error is True:
@@ -248,7 +283,9 @@ class CommitFormat:
         body = lines[1:footer_start] if line_cnt > 1 else []
         footers = [lines[footer_start]] if footer_start < line_cnt else []
 
-        self.debug(f'--HEADER--\n{header}\n---BODY---\n{body}\n--FOOTER--\n{footers}\n----------')
+        self.debug(
+            f"--HEADER--\n{header}\n---BODY---\n{body}\n--FOOTER--\n{footers}\n----------"
+        )
 
         return header, body, footers, lines
 
@@ -260,17 +297,19 @@ class CommitFormat:
         cfg = self.commit_template
 
         footer_required = False
-        if cfg.has_section('footer') and cfg.has_option('footer', 'required'):
+        if cfg.has_section("footer") and cfg.has_option("footer", "required"):
             try:
-                footer_required = cfg.getboolean('footer', 'required')
+                footer_required = cfg.getboolean("footer", "required")
             except ValueError:
                 footer_required = False
 
-        header, body, footers, all_lines = self._split_message(commit_message, footer_required)
+        header, body, footers, all_lines = self._split_message(
+            commit_message, footer_required
+        )
 
         # Header checks
-        if cfg.has_section('header') and cfg.has_option('header', 'pattern'):
-            pattern = cfg.get('header', 'pattern')
+        if cfg.has_section("header") and cfg.has_option("header", "pattern"):
+            pattern = cfg.get("header", "pattern")
             if not re.match(pattern, header):
                 errors += 1
                 self.warning(f"Commit {commit}: header does not match required pattern")
@@ -280,9 +319,11 @@ class CommitFormat:
         # Body separation check
 
         blank_after_header = False
-        if cfg.has_section('body') and cfg.has_option('body', 'blank_line_after_header'):
+        if cfg.has_section("body") and cfg.has_option(
+            "body", "blank_line_after_header"
+        ):
             try:
-                blank_after_header = cfg.getboolean('body', 'blank_line_after_header')
+                blank_after_header = cfg.getboolean("body", "blank_line_after_header")
             except ValueError:
                 blank_after_header = False
 
@@ -293,9 +334,9 @@ class CommitFormat:
 
         # Body emptiness check
         allow_empty = True
-        if cfg.has_section('body') and cfg.has_option('body', 'allow_empty'):
+        if cfg.has_section("body") and cfg.has_option("body", "allow_empty"):
             try:
-                allow_empty = cfg.getboolean('body', 'allow_empty')
+                allow_empty = cfg.getboolean("body", "allow_empty")
             except ValueError:
                 allow_empty = True
 
@@ -311,10 +352,13 @@ class CommitFormat:
             self.warning(f"Commit {commit}: missing required footer section")
 
         # Footer line pattern
-        if (footer_required and len(footers) > 0
-            and cfg.has_section('footer')
-            and cfg.has_option('footer', 'pattern')):
-            fpattern = cfg.get('footer', 'pattern')
+        if (
+            footer_required
+            and len(footers) > 0
+            and cfg.has_section("footer")
+            and cfg.has_option("footer", "pattern")
+        ):
+            fpattern = cfg.get("footer", "pattern")
             compiled = re.compile(fpattern)
             for line in footers:
                 if line.strip() == "":
@@ -327,33 +371,51 @@ class CommitFormat:
 
         return errors
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Perform various checks on commit messages.")
-    parser.add_argument('-V', '--version',
-                        action='version',
-                        version=f'%(prog)s {get_version()}')
-    parser.add_argument('-ns', '--no-spelling',
-                        action='store_true',
-                        help="disable checking misspelled words")
-    parser.add_argument('-l', '--limit',
-                        type=int,
-                        default=72,
-                        help="commit lines maximum length. Default: '72' ('0' => no line limit)")
-    parser.add_argument('-t', '--template',
-                        type=str,
-                        default=None,
-                        help="path to a commit-format template file to validate header/body/footer "
-                        "commit message structure")
-    parser.add_argument('-b', '--base',
-                        type=str,
-                        default="main",
-                        help="name of the base branch. Default 'main'")
-    parser.add_argument('-a', '--all',
-                        action='store_true',
-                        help="check all commits (including base branch commits)")
-    parser.add_argument('-v', '--verbosity',
-                        action='store_true',
-                        help="increase output verbosity")
+    parser = argparse.ArgumentParser(
+        description="Perform various checks on commit messages."
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {get_version()}"
+    )
+    parser.add_argument(
+        "-ns",
+        "--no-spelling",
+        action="store_true",
+        help="disable checking misspelled words",
+    )
+    parser.add_argument(
+        "-l",
+        "--limit",
+        type=int,
+        default=72,
+        help="commit lines maximum length. Default: '72' ('0' => no line limit)",
+    )
+    parser.add_argument(
+        "-t",
+        "--template",
+        type=str,
+        default=None,
+        help="path to a commit-format template file to validate header/body/footer "
+        "commit message structure",
+    )
+    parser.add_argument(
+        "-b",
+        "--base",
+        type=str,
+        default="main",
+        help="name of the base branch. Default 'main'",
+    )
+    parser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        help="check all commits (including base branch commits)",
+    )
+    parser.add_argument(
+        "-v", "--verbosity", action="store_true", help="increase output verbosity"
+    )
     args = parser.parse_args()
 
     commit_format = CommitFormat(verbosity=args.verbosity)
@@ -373,19 +435,25 @@ def main():
         commit_list = commit_format.list_unique_commits(current_branch, args.base)
 
     if not commit_list:
-        commit_format.error(f"Error:{RESET} branch {GREEN}{current_branch}{RESET} "
-                            f"has no diff commit with base branch {GREEN}{args.base}{RESET}")
+        commit_format.error(
+            f"Error:{RESET} branch {GREEN}{current_branch}{RESET} "
+            f"has no diff commit with base branch {GREEN}{args.base}{RESET}"
+        )
         sys.exit(1)
 
-    commit_format.debug(f"Checking {GREEN}{len(commit_list)}{RESET} "
-                        "commits on branch {GREEN}{current_branch}{RESET}")
+    commit_format.debug(
+        f"Checking {GREEN}{len(commit_list)}{RESET} "
+        "commits on branch {GREEN}{current_branch}{RESET}"
+    )
 
     for commit in commit_list:
         error_on_commit = 0
         commit_message = commit_format.get_commit_message(commit)
         if args.no_spelling is False:
             error_on_commit += commit_format.spell_check(commit, commit_message)
-        error_on_commit += commit_format.lines_length(commit, commit_message, args.limit)
+        error_on_commit += commit_format.lines_length(
+            commit, commit_message, args.limit
+        )
         if commit_format.commit_template is not None:
             error_on_commit += commit_format.template_check(commit, commit_message)
 
@@ -396,5 +464,6 @@ def main():
 
     sys.exit(error_found)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,20 @@ dependencies = [
   "codespell"
 ]
 
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/AlexFabre/commit-format"
 Issues = "https://github.com/AlexFabre/commit-format/issues"
 
 [project.scripts]
 commit-format = "commit_format.commit_format:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"
+python_classes = "Test*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "commit_format"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   { name="Alex Fabre", email="m.alexfabre@gmail.com" },
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# pylint: skip-file
+__author__ = "Alex Fabre"

--- a/tests/test_commit_format.py
+++ b/tests/test_commit_format.py
@@ -1,0 +1,288 @@
+# pylint: disable=C0114
+# pylint: disable=C0115
+# pylint: disable=C0116
+# pylint: disable=W0212
+# pylint: disable=W0612
+# pylint: disable=R0903
+
+import pytest
+
+from commit_format.commit_format import (
+    is_url,
+    contains_url,
+    CommitFormat,
+    find_config_file,
+    get_version,
+)
+
+
+class TestIsUrl:
+    def test_valid_https_url(self):
+        assert is_url("https://github.com/user/repo") is True
+
+    def test_valid_http_url(self):
+        assert is_url("http://example.com") is True
+
+    def test_valid_url_with_path(self):
+        assert is_url("https://example.com/path/to/resource") is True
+
+    def test_invalid_url_no_scheme(self):
+        assert is_url("example.com") is False
+
+    def test_invalid_url_no_netloc(self):
+        assert is_url("https://") is False
+
+    def test_plain_text(self):
+        assert is_url("just some text") is False
+
+    def test_empty_string(self):
+        assert is_url("") is False
+
+    def test_file_path(self):
+        assert is_url("/path/to/file") is False
+
+
+class TestContainsUrl:
+    def test_line_with_url(self):
+        assert contains_url("Check this https://example.com for details") is True
+
+    def test_line_without_url(self):
+        assert contains_url("This is just plain text") is False
+
+    def test_url_in_parentheses(self):
+        assert contains_url("See (https://example.com) for more") is True
+
+    def test_url_in_brackets(self):
+        assert contains_url("[1] https://example.com") is True
+
+    def test_no_slash_quick_exit(self):
+        assert contains_url("no slashes here") is False
+
+    def test_path_not_url(self):
+        assert contains_url("see src/main.py for details") is False
+
+
+class TestCommitFormatInit:
+    def test_default_verbosity(self):
+        cf = CommitFormat()
+        assert cf.verbosity is False
+        assert cf.commit_template is None
+
+    def test_verbosity_enabled(self):
+        cf = CommitFormat(verbosity=True)
+        assert cf.verbosity is True
+
+
+class TestSplitMessage:
+    def test_header_only(self):
+        cf = CommitFormat()
+        header, body, footers, lines = cf._split_message("fix: simple fix", False)
+        assert header == "fix: simple fix"
+        assert body == []
+        assert not footers
+        assert lines == ["fix: simple fix"]
+
+    def test_header_and_body(self):
+        cf = CommitFormat()
+        message = "fix: bug fix\n\nThis fixes the bug in the parser."
+        header, body, footers, lines = cf._split_message(message, False)
+        assert header == "fix: bug fix"
+        assert body == ["", "This fixes the bug in the parser."]
+        assert not footers
+
+    def test_header_body_and_footer(self):
+        cf = CommitFormat()
+        message = (
+            "feat: new feature\n\nAdded new functionality.\n\nSigned-off-by: Author"
+        )
+        header, body, footers, lines = cf._split_message(message, True)
+        assert header == "feat: new feature"
+        assert body == ["", "Added new functionality.", ""]
+        assert footers == ["Signed-off-by: Author"]
+
+    def test_footer_with_trailing_empty_lines(self):
+        cf = CommitFormat()
+        message = "fix: bug\n\nBody text.\n\nSigned-off-by: Author\n\n"
+        header, body, footers, lines = cf._split_message(message, True)
+        assert header == "fix: bug"
+        assert footers == ["Signed-off-by: Author"]
+
+    def test_empty_message(self):
+        cf = CommitFormat()
+        header, body, footers, lines = cf._split_message("", False)
+        assert header == ""
+        assert body == []
+        assert not footers
+
+
+class TestLinesLength:
+    def test_all_lines_within_limit(self):
+        cf = CommitFormat()
+        message = "Short header\n\nShort body line."
+        errors = cf.lines_length("abc123", message, 72)
+        assert errors == 0
+
+    def test_line_exceeds_limit(self):
+        cf = CommitFormat()
+        message = "fix: bug\n\n" + "a" * 80
+        errors = cf.lines_length("abc123", message, 72)
+        assert errors == 1
+
+    def test_limit_disabled(self):
+        cf = CommitFormat()
+        message = "a" * 200
+        errors = cf.lines_length("abc123", message, 0)
+        assert errors == 0
+
+    def test_url_line_allowed(self):
+        cf = CommitFormat()
+        message = (
+            "fix: add reference\n\n[1] https://example.com/very/long/path/to/resource"
+        )
+        errors = cf.lines_length("abc123", message, 72)
+        assert errors == 0
+
+    def test_url_wrong_format(self):
+        cf = CommitFormat()
+        # URL line without proper [index] format
+        message = (
+            "fix: refs\n\nSee this very long line with url https://example.com/path"
+        )
+        errors = cf.lines_length("abc123", message, 50)
+        assert errors == 1
+
+
+class TestTemplateCheck:
+    @pytest.fixture
+    def cf_with_template(self, tmp_path):
+        cf = CommitFormat()
+        template_file = tmp_path / ".commit-format"
+        template_file.write_text("""[header]
+pattern = ^(fix: |feat: |doc: |ci: ).+$
+
+[body]
+allow_empty = false
+blank_line_after_header = true
+
+[footer]
+required = true
+pattern = ^(Signed-off-by: |Refs: ).+$
+""")
+        cf.load_template(str(template_file))
+        return cf
+
+    def test_valid_commit(self, cf_with_template):
+        message = "fix: repair bug\n\nFixed the issue.\n\nSigned-off-by: Author"
+        errors = cf_with_template.template_check("abc123", message)
+        assert errors == 0
+
+    def test_invalid_header_pattern(self, cf_with_template):
+        message = "broken: wrong prefix\n\nBody.\n\nSigned-off-by: Author"
+        errors = cf_with_template.template_check("abc123", message)
+        assert errors >= 1
+
+    def test_missing_blank_line_after_header(self, cf_with_template):
+        message = "fix: bug\nNo blank line here.\n\nSigned-off-by: Author"
+        errors = cf_with_template.template_check("abc123", message)
+        assert errors >= 1
+
+    def test_empty_body_not_allowed(self, cf_with_template):
+        message = "fix: bug\n\n\n\nSigned-off-by: Author"
+        errors = cf_with_template.template_check("abc123", message)
+        assert errors >= 1
+
+    def test_missing_footer(self, cf_with_template):
+        message = "fix: bug\n\nBody content here."
+        errors = cf_with_template.template_check("abc123", message)
+        assert errors >= 1
+
+    def test_invalid_footer_pattern(self, cf_with_template):
+        message = "fix: bug\n\nBody content.\n\nInvalid-footer: Author"
+        errors = cf_with_template.template_check("abc123", message)
+        assert errors >= 1
+
+    def test_no_template_loaded(self):
+        cf = CommitFormat()
+        errors = cf.template_check("abc123", "any message")
+        assert errors == 0
+
+
+class TestLoadTemplate:
+    def test_load_valid_template(self, tmp_path):
+        cf = CommitFormat()
+        template_file = tmp_path / ".commit-format"
+        template_file.write_text("[header]\npattern = ^fix: .+$\n")
+        cf.load_template(str(template_file))
+        assert cf.commit_template is not None
+        assert cf.commit_template.has_section("header")
+
+    def test_load_nonexistent_template(self, tmp_path):
+        cf = CommitFormat()
+        with pytest.raises(SystemExit) as exc_info:
+            cf.load_template(str(tmp_path / "nonexistent"))
+        assert exc_info.value.code == 2
+
+
+class TestFindConfigFile:
+    def test_find_in_current_dir(self, tmp_path, monkeypatch):
+        config_file = tmp_path / ".commit-format"
+        config_file.write_text("[header]\n")
+        monkeypatch.chdir(tmp_path)
+        result = find_config_file()
+        assert result == ".commit-format"
+
+    def test_find_toml_variant(self, tmp_path, monkeypatch):
+        config_file = tmp_path / ".commit-format.toml"
+        config_file.write_text("[header]\n")
+        monkeypatch.chdir(tmp_path)
+        result = find_config_file()
+        assert result == ".commit-format.toml"
+
+    def test_no_config_found(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Mock git to return failure (not in a git repo)
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *args, **kwargs: type(
+                "Result", (), {"returncode": 1, "stdout": ""}
+            )(),
+        )
+        result = find_config_file()
+        assert result is None
+
+
+class TestHighlightWordsInTxt:
+    def test_highlight_single_word(self):
+        cf = CommitFormat()
+        result = cf.highlight_words_in_txt("hello world", ["world"])
+        assert "world" in result
+        assert "\033[91m" in result  # RED color code
+
+    def test_highlight_multiple_words(self):
+        cf = CommitFormat()
+        result = cf.highlight_words_in_txt("foo bar baz", ["foo", "baz"])
+        assert "\033[91m" in result
+
+    def test_no_words_to_highlight(self):
+        cf = CommitFormat()
+        result = cf.highlight_words_in_txt("hello world", [])
+        assert result == "hello world"
+
+
+class TestRemoveAnsiColorCodes:
+    def test_remove_red(self):
+        cf = CommitFormat()
+        result = cf.remove_ansi_color_codes("\033[91mred text\033[0m")
+        assert result == "red text"
+
+    def test_no_codes(self):
+        cf = CommitFormat()
+        result = cf.remove_ansi_color_codes("plain text")
+        assert result == "plain text"
+
+
+class TestGetVersion:
+    def test_returns_string(self):
+        result = get_version()
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
# Summary
- Add --version CLI flag to display the package version
- Add config file auto-discovery (automatically finds .commit-format in current or parent directories)
- Add comprehensive unit test suite with pytest (284 lines of tests)
- Add CI pipelines for pytest and ruff linting
- Format codebase with ruff

# Test plan
- [x] Run commit-format --version to verify version flag works
- [x] Test config file auto-discovery by placing .commit-format in different directories
- [x] Run pytest to verify all unit tests pass
- [x] Verify CI pipelines pass (pytest, ruff)